### PR TITLE
CT: try to download the best quality

### DIFF
--- a/engines/ct.py
+++ b/engines/ct.py
@@ -110,7 +110,9 @@ class CtEngine:
         if quality:
             video = self.get_video(quality)
         else:
-            video = self.videos[0]
+            # setridime podle kvality: z popisku nechame jenom cislo
+            # kvuli audio-description verzi (label AD) pridame 0, abychom to mohli tridit jako cisla
+            video = sorted(self.videos, key=lambda k: int(re.sub(r"\D", "", k.get('label')+"0")), reverse=True)[0]
             log.info('Automaticky vybraná kvalita: {}'.format(video.get('label')) )
 
         base = self.movie.get('base')


### PR DESCRIPTION
For some movies, such as http://www.ceskatelevize.cz/ivysilani/
10362011008-ceske-stoleti/21251212023-velike-bourani-1918/, the first
quality in the list is the audio-desription version. This change tries
to sort the videos by quality (number in the label) and selects the best
one, ignoring the AD one.
