### PR TITLE
playlist: get rid of the initial warning videos

### DIFF
--- a/engines/ct.py
+++ b/engines/ct.py
@@ -97,7 +97,8 @@ class CtEngine:
         xml = ElementTree.fromstring(self.playlist) 
 
         for e in xml.findall('smilRoot/body/switchItem'):
-            if not 'AD'  in e.get('id'):
+            i = e.get('id')
+            if not ('AD' in i or 'BO' in i):
                 self.movie = e
                 break
         


### PR DESCRIPTION
The playlist may begin not just with the advertisement, but also with some kind of warning videos.
This commit is to get rid of it.
